### PR TITLE
Add CallList and APIKeyInfo xml endpoints

### DIFF
--- a/eveapi/api.go
+++ b/eveapi/api.go
@@ -1,8 +1,75 @@
 package eveapi
 
+import (
+	"fmt"
+
+	"golang.org/x/oauth2"
+)
+
 // CCP basic XML Frame
 type xmlAPIFrame struct {
 	Version     int        `xml:"eveapi>version"`
 	CurrentTime EVEXMLTime `xml:"currentTime"`
 	CachedUntil EVEXMLTime `xml:"cachedUntil"`
+}
+
+type EVEAPICallListXML struct {
+	xmlAPIFrame
+	Entries []struct {
+		Kind string `xml:"name,attr"`
+		Rows []struct {
+			Name        string `xml:"name,attr"`
+			Description string `xml:"description,attr"`
+			GroupID     int32  `xml:"groupID,attr"`
+			AccessMask  int64  `xml:"accessMask,attr"`
+			Type        string `xml:"type,attr"`
+		} `xml:"row"`
+	} `xml:"result>rowset"`
+}
+
+func (c *EVEAPIClient) CallList(auth oauth2.TokenSource) (*EVEAPICallListXML, error) {
+	w := &EVEAPICallListXML{}
+	tok, err := auth.Token()
+	if err != nil {
+		return nil, err
+	}
+	url := c.base.XML + fmt.Sprintf("api/CallList.xml.aspx?accessToken=%s", tok.AccessToken)
+	_, err = c.doXML("GET", url, nil, w)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+type EVEAPIKeyInfoXML struct {
+	xmlAPIFrame
+	Key struct {
+		AccessMask int64      `xml:"accessMask,attr"`
+		Type       string     `xml:"type,attr"`
+		Expires    EVEXMLTime `xml:"expires,attr"`
+		Info       struct {
+			CharacterID     int64  `xml:"characterID,attr"`
+			CharacterName   string `xml:"characterName,attr"`
+			CorporationID   int64  `xml:"corporationID,attr"`
+			CorporationName string `xml:"corporationName,attr"`
+			AllianceID      int64  `xml:"allianceID,attr"`
+			AllianceName    string `xml:"allianceName,attr"`
+			FactionID       int64  `xml:"factionID,attr"`
+			FactionName     string `xml:"factionName,attr"`
+		} `xml:"rowset>row"`
+	} `xml:"result>key"`
+}
+
+func (c *EVEAPIClient) APIKeyInfo(auth oauth2.TokenSource) (*EVEAPIKeyInfoXML, error) {
+	w := &EVEAPIKeyInfoXML{}
+	tok, err := auth.Token()
+	if err != nil {
+		return nil, err
+	}
+	url := c.base.XML + fmt.Sprintf("account/APIKeyInfo.xml.aspx?accessToken=%s&accessType=corporation", tok.AccessToken)
+	_, err = c.doXML("GET", url, nil, w)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
 }


### PR DESCRIPTION
Since so much functionality still relies on the XML API, we will still need to use it for a while longer. These two calls can be useful for diagnostic information.