### PR TITLE
Replace rateLimiter with golang.org/x/time/rate

### DIFF
--- a/eveapi/rateLimiter.go
+++ b/eveapi/rateLimiter.go
@@ -3,53 +3,22 @@ package eveapi
 import (
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 type rateLimiter struct {
-	throttle  chan time.Time
-	rate      time.Duration
-	ticker    *time.Ticker
-	burstRate int
+	lim *rate.Limiter
 }
 
 func newRateLimiter(requestsPerSecond int, burstRate int) *rateLimiter {
-	c := &rateLimiter{
-		throttle:  make(chan time.Time, burstRate),
-		rate:      time.Second / (time.Duration)(requestsPerSecond),
-		burstRate: burstRate,
-	}
-	c.startRatelimiter()
-	return c
-}
-
-func (c *rateLimiter) startRatelimiter() {
-	// Create the timed limiter
-	c.ticker = time.NewTicker(c.rate)
-
-	// Fill the buffer with the burst tokens
-	for i := 0; i < c.burstRate; i++ {
-		c.throttle <- time.Now()
-	}
-
-	// Start the rate limiter
-	go c.tick()
-}
-
-func (c *rateLimiter) tick() {
-	for t := range c.ticker.C {
-		select {
-		case c.throttle <- t:
-		default:
-		}
-	}
-}
-
-func (c *rateLimiter) stop() {
-	c.ticker.Stop()
+	lim := rate.NewLimiter(rate.Limit(requestsPerSecond), burstRate)
+	return &rateLimiter{lim}
 }
 
 func (c *rateLimiter) throttleRequest() {
-	<-c.throttle
+	r := c.lim.Reserve()
+	time.Sleep(r.Delay())
 }
 
 type concurrencyLimiter struct {


### PR DESCRIPTION
Hi @antihax !

I noticed my applications were constantly using 2% CPU, so I did a little profiling with pprof and found that the rateLimiter implementation in goesi was causing the issue. Here's the top handful of rows from `top100` in go tool pprof after about 30 seconds of running:

```
Showing nodes accounting for 600ms, 100% of 600ms total
      flat  flat%   sum%        cum   cum%
     190ms 31.67% 31.67%      190ms 31.67%  runtime.mach_semaphore_signal
     180ms 30.00% 61.67%      180ms 30.00%  runtime.mach_semaphore_wait
      80ms 13.33% 75.00%       80ms 13.33%  runtime.(*waitq).dequeue
      50ms  8.33% 83.33%       50ms  8.33%  runtime.usleep
      30ms  5.00% 88.33%       50ms  8.33%  runtime.notetsleep
      20ms  3.33% 91.67%       20ms  3.33%  runtime.mach_semaphore_timedwait
      10ms  1.67% 93.33%       10ms  1.67%  github.com/motki/cli/vendor/github.com/antihax/goesi/eveapi.(*rateLimiter).tick
      10ms  1.67% 95.00%       10ms  1.67%  runtime.acquireSudog
      10ms  1.67% 96.67%       10ms  1.67%  runtime.lock
      10ms  1.67% 98.33%       10ms  1.67%  runtime.memclrNoHeapPointers
      10ms  1.67%   100%      100ms 16.67%  runtime.startm
```

The very low tick rate (50ms for `authedThrottle` and 6.666ms for `anonThrottle`) caused essentially a spinwait in the `tick` method.

There is a "polling" rate limiter implementation in `x`, calculating what rate limiting needs to occur when `lim.Reserve()` is called. It turned out to be a drop-in replacement -- even the test still passes. This also dropped average load in my programs to 0.0%.

Let me know what you think. And as always, thanks for the excellent library!