### PR TITLE
Add ParseTime to Helpers

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,10 @@
 package goesi
 
-import "regexp"
+import (
+	"math"
+	"regexp"
+	"time"
+)
 
 // https://community.eveonline.com/support/policies/naming-policy-en/
 func ValidCharacterName(name string) bool {
@@ -25,4 +29,18 @@ func FactionNameToID(faction string) int32 {
 		return 500004
 	}
 	return 0
+}
+
+func ParseTime(input int64) time.Time {
+	maxd := time.Duration(math.MaxInt64).Truncate(100 * time.Nanosecond)
+	maxdUnits := int64(maxd / 100)
+	t := time.Date(1601, 1, 1, 0, 0, 0, 0, time.UTC)
+	for input > maxdUnits {
+		t = t.Add(maxd)
+		input -= maxdUnits
+	}
+	if input != 0 {
+		t = t.Add(time.Duration(input * 100))
+	}
+	return t
 }


### PR DESCRIPTION
ParseTime allows to read notification times in a manageable format.
(Source: https://stackoverflow.com/questions/57901280/calculate-time-time-from-timestamp-starting-from-1601-01-01-in-go)

ESI timestamp format sometimes is an int64 (like: 132656184613915270, which is 2021-05-16 06:01:01.391527 +0000 UTC), this methods allows to use this timestamp in our applications more easily.